### PR TITLE
Fixed plugin for windows users

### DIFF
--- a/src/main/scala/FmppPlugin.scala
+++ b/src/main/scala/FmppPlugin.scala
@@ -3,6 +3,7 @@ package fmpp
 import sbt._
 import Keys._
 import sbt.Fork
+import java.io.File
 
 import java.io.File
 
@@ -69,7 +70,7 @@ object FmppPlugin extends Plugin {
             Fork.java(
               javaHome,
               List(
-                "-cp", classpath.map(_.data).mkString(":"), mainClass,
+                "-cp", classpath.map(_.data).mkString(File.pathSeparator), mainClass,
                 "-S", input.toString, "-O", output.toString,
                 "--replace-extensions=fm, " + x,
                 "-M", "execute(**/*.fm), ignore(**/*)" 


### PR DESCRIPTION
The plugin was not working on windows: path separator on windows is ";"
rather than ":".
