### PR TITLE
Fix the output directory

### DIFF
--- a/src/main/scala/FmppPlugin.scala
+++ b/src/main/scala/FmppPlugin.scala
@@ -59,12 +59,12 @@ object FmppPlugin extends Plugin {
     streams: TaskStreams,
     cache: File
   ) = {
-    IO.delete(output)
     sources.flatMap(x => {
       val input = source / x
       if (input.exists) {
         val cached = FileFunction.cached(cache / "fmpp" / x, FilesInfo.lastModified, FilesInfo.exists) {
           (in: Set[File]) => {
+            IO.delete(output)
             Fork.java(
               javaHome,
               List(


### PR DESCRIPTION
According to the documentation of the recent version of sbt, the output directory should be a subdirectory of the `sourceManaged in Compile`, and not be the `sourceManaged in Compile` itself.
For multiple projects, sbt-idea excludes the directory from the list of source directories without conforming to this.

References:
    http://www.scala-sbt.org/0.13.1/docs/Howto/generatefiles.html
    https://github.com/mpeltonen/sbt-idea/issues/209
    https://github.com/sbt/sbt-scalabuff/pull/6
